### PR TITLE
Update Cython wrapper to use NumPy memoryview interface

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,9 +13,9 @@ jobs:
     name: python source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -33,7 +33,7 @@ jobs:
       - name: run pytest
         run: pytest tests/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ startsWith(github.ref, 'refs/tags') }}
         with:
           path: ./dist/*.tar.gz
@@ -49,7 +49,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -71,7 +71,7 @@ jobs:
       - name: run pytests
         run: pytest tests
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ startsWith(github.ref, 'refs/tags') }}
         with:
           path: ./dist/*.whl
@@ -84,7 +84,7 @@ jobs:
     needs: [build_wheels, from-sdist]
     steps:
       - name: Download wheels and sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Move wheels and source distribution to dist/
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,5 +1,10 @@
 name: Python Build
 
+env:
+  # Set to avoid errors when building FFTW with CMake v4+
+  # https://github.com/FFTW/fftw3/issues/381
+  CMAKE_POLICY_VERSION_MINIMUM: 3.5
+
 "on":
   push:
     branches: ["main"]

--- a/src/so3/bindings.pyx
+++ b/src/so3/bindings.pyx
@@ -1,11 +1,6 @@
 # cython: language_level=3
 
-# import both numpy and the Cython declarations for numpy
 import numpy as np
-cimport numpy as np
-
-# if you want to use the Numpy-C-API from Cython
-np.import_array()
 
 #----------------------------------------------------------------------------------------------------#
 
@@ -317,7 +312,7 @@ def is_elmn_non_zero(int el, int m, int n, so3_parameters):
 
 
 # forward and inverse for MW and MWSS for complex functions
-def inverse(np.ndarray[ double complex, ndim=1, mode="c"] flmn not None, so3_parameters not None):
+def inverse(double complex[::1] flm not None, so3_parameters not None):
     cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
 
     if so3_parameters.reality:
@@ -331,7 +326,7 @@ def inverse(np.ndarray[ double complex, ndim=1, mode="c"] flmn not None, so3_par
 
     return f
 
-def forward(np.ndarray[ double complex, ndim=1, mode="c"] f not None, so3_parameters not None):
+def forward(double complex[::1] f not None, so3_parameters not None):
     cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
 
     if so3_parameters.reality:
@@ -368,9 +363,9 @@ def get_convolved_parameters(f_so3_parameters, g_so3_parameters):
     return SO3Parameters().from_dict(h_parameters)
 
 def convolve(
-    np.ndarray[ double complex, ndim=1, mode="c"] f not None, 
+    double complex[::1] f not None,
     f_parameters,
-    np.ndarray[ double complex, ndim=1, mode="c"] g not None, 
+    double complex[::1] g not None,
     g_parameters
     ):
 
@@ -394,9 +389,9 @@ def convolve(
     return h, h_parameters
 
 def convolve_harmonic(    
-    np.ndarray[ double complex, ndim=1, mode="c"] flmn not None, 
+    double complex[::1] flmn not None,
     f_parameters,
-    np.ndarray[ double complex, ndim=1, mode="c"] glmn not None, 
+    double complex[::1] glmn not None,
     g_parameters
     ):
 
@@ -422,8 +417,8 @@ def convolve_harmonic(
 
 def s2toso3_harmonic_convolution(
     h_so3_parameters,
-    np.ndarray[ double complex, ndim=1, mode="c"] flm not None,
-    np.ndarray[ double complex, ndim=1, mode="c"] glm not None):
+    double complex[::1] flm not None,
+    double complex[::1] glm not None):
 
     cdef so3_parameters_t h_parameters=create_parameter_struct(h_so3_parameters)
 

--- a/src/so3/bindings.pyx
+++ b/src/so3/bindings.pyx
@@ -312,32 +312,48 @@ def is_elmn_non_zero(int el, int m, int n, so3_parameters):
 
 
 # forward and inverse for MW and MWSS for complex functions
-def inverse(double complex[::1] flm not None, so3_parameters not None):
-    cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
-
+def inverse(double complex[::1] flmn not None, so3_parameters not None):
+    cdef so3_parameters_t parameters = create_parameter_struct(so3_parameters)
     if so3_parameters.reality:
-        f_length = f_size(so3_parameters)
-        f = np.zeros([f_length,], dtype=float)
-        so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
+        return np.array(_inverse_real(flmn, parameters))
     else:
-        f_length = f_size(so3_parameters)
-        f = np.zeros([f_length,], dtype=complex)
-        so3_core_inverse_via_ssht(<double complex*> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
+        return np.array(_inverse_complex(flmn, parameters))
 
+cdef double[::1] _inverse_real(double complex[::1] flmn, so3_parameters_t parameters):
+    cdef int f_length = so3_sampling_f_size(&parameters)
+    cdef double[::1] f = np.zeros([f_length,], dtype=float)
+    so3_core_inverse_via_ssht_real(&f[0], &flmn[0], &parameters)
     return f
 
-def forward(double complex[::1] f not None, so3_parameters not None):
-    cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
+cdef double complex[::1] _inverse_complex(double complex[::1] flmn, so3_parameters_t parameters):
+    cdef int f_length = so3_sampling_f_size(&parameters)
+    cdef double complex[::1] f = np.zeros([f_length,], dtype=complex)
+    so3_core_inverse_via_ssht(&f[0], &flmn[0], &parameters)
+    return f
 
-    if so3_parameters.reality:
-        flmn_length = flmn_size(so3_parameters)
-        flmn = np.zeros([flmn_length,], dtype=float)
-        so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
+ctypedef fused real_or_complex:
+    double
+    double complex
+
+def forward(real_or_complex[::1] f not None, so3_parameters not None):
+    cdef so3_parameters_t parameters = create_parameter_struct(so3_parameters)
+    if real_or_complex is double:
+        if not so3_parameters.reality:
+            raise ValueError("f has a real data type but reality flag not set")
+        return np.array(_forward_real(f, parameters))
     else:
-        flmn_length = flmn_size(so3_parameters)
-        flmn = np.zeros([flmn_length,], dtype=complex)
-        so3_core_forward_via_ssht(<double complex*> np.PyArray_DATA(flmn), <const double complex*> np.PyArray_DATA(f), &parameters)
+        return np.array(_forward_complex(f, parameters))
+    
+cdef double complex[::1] _forward_real(double[::1] f, so3_parameters_t parameters):
+    cdef int flmn_length = so3_sampling_flmn_size(&parameters)
+    cdef double complex[::1] flmn = np.zeros([flmn_length,], dtype=complex)
+    so3_core_forward_via_ssht_real(&flmn[0], &f[0], &parameters)
+    return flmn
 
+cdef double complex[::1] _forward_complex(double complex[::1] f, so3_parameters_t parameters):
+    cdef int flmn_length = so3_sampling_flmn_size(&parameters)
+    cdef double complex[::1] flmn = np.zeros([flmn_length,], dtype=complex)
+    so3_core_forward_via_ssht(&flmn[0], &f[0], &parameters)
     return flmn
 
 # convolution both in real and harmonic space and helper params function
@@ -376,14 +392,14 @@ def convolve(
     cdef so3_parameters_t h_parameters_struct=create_parameter_struct(h_parameters)
 
     h_length = f_size(h_parameters)
-    h = np.zeros([h_length,], dtype=complex)
+    cdef double complex[::1] h = np.zeros([h_length,], dtype=complex)
 
     so3_conv_convolution(
-        <double complex *> np.PyArray_DATA(h),
+        &h[0],
         &h_parameters_struct,
-        <const double complex *> np.PyArray_DATA(f),
+        &f[0],
         &f_parameters_struct,
-        <const double complex *> np.PyArray_DATA(g),
+        &g[0],
         &g_parameters_struct
     )
     return h, h_parameters
@@ -403,14 +419,14 @@ def convolve_harmonic(
     cdef so3_parameters_t h_parameters_struct=create_parameter_struct(h_parameters)
 
     hlmn_length = flmn_size(h_parameters)
-    hlmn = np.zeros([hlmn_length,], dtype=complex)
+    cdef double complex[::1] hlmn = np.zeros([hlmn_length,], dtype=complex)
 
     so3_conv_convolution(
-        <double complex *> np.PyArray_DATA(hlmn),
+        &hlmn[0],
         &h_parameters_struct,
-        <const double complex *> np.PyArray_DATA(flmn),
+        &flmn[0],
         &f_parameters_struct,
-        <const double complex *> np.PyArray_DATA(glmn),
+        &glmn[0],
         &g_parameters_struct
     )
     return hlmn, h_parameters
@@ -423,14 +439,9 @@ def s2toso3_harmonic_convolution(
     cdef so3_parameters_t h_parameters=create_parameter_struct(h_so3_parameters)
 
     hlmn_length = flmn_size(h_so3_parameters)
-    hlmn = np.zeros([hlmn_length,], dtype=complex)
+    cdef double complex[::1] hlmn = np.zeros([hlmn_length,], dtype=complex)
 
-    so3_conv_s2toso3_harmonic_convolution(
-    <double complex *> np.PyArray_DATA(hlmn), 
-    &h_parameters,
-    <const double complex *> np.PyArray_DATA(flm),
-    <const double complex *> np.PyArray_DATA(glm)
-    )
+    so3_conv_s2toso3_harmonic_convolution(&hlmn[0], &h_parameters, &flm[0], &glm[0])
     return hlmn
 
 def test_func():

--- a/tests/test_pyso3.py
+++ b/tests/test_pyso3.py
@@ -22,6 +22,18 @@ def test_pyso3():
     assert f_before == approx(f)
 
 
+def test_pyso3_reality():
+
+    f_p = so3.create_parameter_dict(16, 8, reality=1)
+    f_length = so3.f_size(f_p)
+    rng = np.random.default_rng()
+    f = rng.normal(size=f_length)
+    flmn = so3.forward(f, f_p)
+    f_recov = so3.inverse(flmn, f_p)
+
+    assert np.allclose(f, f_recov)
+
+
 def test_convolve_smoke_test():
     rng = np.random.default_rng()
     g_p = so3.create_parameter_dict(16, 8)

--- a/tests/test_pyso3.py
+++ b/tests/test_pyso3.py
@@ -1,18 +1,20 @@
 import numpy as np
+import pytest
 from pytest import approx
 
 import so3
 
 
-def test_pyso3():
-
-    f_p = so3.create_parameter_dict(16, 8)
+@pytest.mark.parametrize("L, N, L0", [(16, 8, 0), (16, 8, 1), (4, 1, 0), (3, 2, 0)])
+@pytest.mark.parametrize("reality", [False, True])
+def test_pyso3(L, N, L0, reality):
+    f_p = so3.create_parameter_dict(L, N, L0, reality=reality * 1)
     f_length = so3.f_size(f_p)
     rng = np.random.default_rng()
-    f_before = rng.normal(size=(f_length, 2)) @ [1, 1j]
+    multiplier = [1, 1] if reality else [1, 1j]
+    f_before = rng.normal(size=(f_length, 2)) @ multiplier
     flmn = so3.forward(f_before, f_p)
     f_before = so3.inverse(flmn, f_p)
-
     flmn = so3.forward(f_before, f_p)
 
     f = so3.inverse(flmn, f_p)
@@ -20,18 +22,6 @@ def test_pyso3():
 
     assert flmn_new == approx(flmn)
     assert f_before == approx(f)
-
-
-def test_pyso3_reality():
-
-    f_p = so3.create_parameter_dict(16, 8, reality=1)
-    f_length = so3.f_size(f_p)
-    rng = np.random.default_rng()
-    f = rng.normal(size=f_length)
-    flmn = so3.forward(f, f_p)
-    f_recov = so3.inverse(flmn, f_p)
-
-    assert np.allclose(f, f_recov)
 
 
 def test_convolve_smoke_test():


### PR DESCRIPTION
Builds of `so3` are currently failing as part of our [test workflows for S2FFT](https://github.com/astro-informatics/s2fft/actions/runs/15369023404/job/43245631496). This is happening specifically on Ubuntu / Python 3.8 in our test matrix, but from some local testing I think it may also affect other Python versions but the workflows on GitHub Actions are using cached wheels from a previously successful build. 

The Cython build errors causing the issue (see below) all seem to relate to use of the [legacy NumPy buffer based Cython integration](https://docs.cython.org/en/stable/src/tutorial/numpy.html) and the [NumPy C Array API ](https://numpy.org/doc/stable/reference/c-api/array.html)rather than the more modern [typed memoryview based interface](https://docs.cython.org/en/latest/src/userguide/numpy_tutorial.html). 

<details>
<summary>Cython build errors</summary>

```
 Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          return bool(so3_sampling_is_elmn_non_zero_return_int(el, m, n, &parameters))
      
      
      # forward and inverse for MW and MWSS for complex functions
      def inverse(np.ndarray[ double complex, ndim=1, mode="c"] flmn not None, so3_parameters not None):
                  ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:320:12: 'ndarray' is not a type identifier
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              f = np.zeros([f_length,], dtype=complex)
              so3_core_inverse_via_ssht(<double complex*> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
      
          return f
      
      def forward(np.ndarray[ double complex, ndim=1, mode="c"] f not None, so3_parameters not None):
                  ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:334:12: 'ndarray' is not a type identifier
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          )
      
          return SO3Parameters().from_dict(h_parameters)
      
      def convolve(
          np.ndarray[ double complex, ndim=1, mode="c"] f not None,
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:371:4: 'ndarray' is not a type identifier
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          return SO3Parameters().from_dict(h_parameters)
      
      def convolve(
          np.ndarray[ double complex, ndim=1, mode="c"] f not None,
          f_parameters,
          np.ndarray[ double complex, ndim=1, mode="c"] g not None,
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:373:4: 'ndarray' is not a type identifier
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              &g_parameters_struct
          )
          return h, h_parameters
      
      def convolve_harmonic(
          np.ndarray[ double complex, ndim=1, mode="c"] flmn not None,
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:397:4: 'ndarray' is not a type identifier
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          return h, h_parameters
      
      def convolve_harmonic(
          np.ndarray[ double complex, ndim=1, mode="c"] flmn not None,
          f_parameters,
          np.ndarray[ double complex, ndim=1, mode="c"] glmn not None,
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:399:4: 'ndarray' is not a type identifier
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          )
          return hlmn, h_parameters
      
      def s2toso3_harmonic_convolution(
          h_so3_parameters,
          np.ndarray[ double complex, ndim=1, mode="c"] flm not None,
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:425:4: 'ndarray' is not a type identifier
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          return hlmn, h_parameters
      
      def s2toso3_harmonic_convolution(
          h_so3_parameters,
          np.ndarray[ double complex, ndim=1, mode="c"] flm not None,
          np.ndarray[ double complex, ndim=1, mode="c"] glm not None):
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:426:4: 'ndarray' is not a type identifier
      warning: /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:194:39: Not all members given for struct 'so3_parameters_t'
      warning: /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:222:39: Not all members given for struct 'so3_parameters_t'
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
      
          if so3_parameters.reality:
              f_length = f_size(so3_parameters)
              f = np.zeros([f_length,], dtype=float)
              so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
                                             ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:326:39: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
      
          if so3_parameters.reality:
              f_length = f_size(so3_parameters)
              f = np.zeros([f_length,], dtype=float)
              so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
                                             ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:326:39: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
      
          if so3_parameters.reality:
              f_length = f_size(so3_parameters)
              f = np.zeros([f_length,], dtype=float)
              so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
                                                                            ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:326:70: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
      
          if so3_parameters.reality:
              f_length = f_size(so3_parameters)
              f = np.zeros([f_length,], dtype=float)
              so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
                                                                            ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:326:70: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              f = np.zeros([f_length,], dtype=float)
              so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
          else:
              f_length = f_size(so3_parameters)
              f = np.zeros([f_length,], dtype=complex)
              so3_core_inverse_via_ssht(<double complex*> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
                                        ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:330:34: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              f = np.zeros([f_length,], dtype=float)
              so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
          else:
              f_length = f_size(so3_parameters)
              f = np.zeros([f_length,], dtype=complex)
              so3_core_inverse_via_ssht(<double complex*> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
                                        ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:330:34: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              f = np.zeros([f_length,], dtype=float)
              so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
          else:
              f_length = f_size(so3_parameters)
              f = np.zeros([f_length,], dtype=complex)
              so3_core_inverse_via_ssht(<double complex*> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
                                                                              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:330:72: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              f = np.zeros([f_length,], dtype=float)
              so3_core_inverse_via_ssht_real(<double *> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
          else:
              f_length = f_size(so3_parameters)
              f = np.zeros([f_length,], dtype=complex)
              so3_core_inverse_via_ssht(<double complex*> np.PyArray_DATA(f), <const double complex*> np.PyArray_DATA(flmn), &parameters)
                                                                              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:330:72: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
      
          if so3_parameters.reality:
              flmn_length = flmn_size(so3_parameters)
              flmn = np.zeros([flmn_length,], dtype=float)
              so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
                                             ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:340:39: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
      
          if so3_parameters.reality:
              flmn_length = flmn_size(so3_parameters)
              flmn = np.zeros([flmn_length,], dtype=float)
              so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
                                             ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:340:39: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
      
          if so3_parameters.reality:
              flmn_length = flmn_size(so3_parameters)
              flmn = np.zeros([flmn_length,], dtype=float)
              so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
                                                                                      ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:340:80: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef so3_parameters_t parameters=create_parameter_struct(so3_parameters)
      
          if so3_parameters.reality:
              flmn_length = flmn_size(so3_parameters)
              flmn = np.zeros([flmn_length,], dtype=float)
              so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
                                                                                      ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:340:80: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              flmn = np.zeros([flmn_length,], dtype=float)
              so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
          else:
              flmn_length = flmn_size(so3_parameters)
              flmn = np.zeros([flmn_length,], dtype=complex)
              so3_core_forward_via_ssht(<double complex*> np.PyArray_DATA(flmn), <const double complex*> np.PyArray_DATA(f), &parameters)
                                        ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:344:34: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              flmn = np.zeros([flmn_length,], dtype=float)
              so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
          else:
              flmn_length = flmn_size(so3_parameters)
              flmn = np.zeros([flmn_length,], dtype=complex)
              so3_core_forward_via_ssht(<double complex*> np.PyArray_DATA(flmn), <const double complex*> np.PyArray_DATA(f), &parameters)
                                        ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:344:34: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              flmn = np.zeros([flmn_length,], dtype=float)
              so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
          else:
              flmn_length = flmn_size(so3_parameters)
              flmn = np.zeros([flmn_length,], dtype=complex)
              so3_core_forward_via_ssht(<double complex*> np.PyArray_DATA(flmn), <const double complex*> np.PyArray_DATA(f), &parameters)
                                                                                 ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:344:75: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              flmn = np.zeros([flmn_length,], dtype=float)
              so3_core_forward_via_ssht_real(<double complex*> np.PyArray_DATA(flmn), <const double *> np.PyArray_DATA(f), &parameters)
          else:
              flmn_length = flmn_size(so3_parameters)
              flmn = np.zeros([flmn_length,], dtype=complex)
              so3_core_forward_via_ssht(<double complex*> np.PyArray_DATA(flmn), <const double complex*> np.PyArray_DATA(f), &parameters)
                                                                                 ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:344:75: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          h_length = f_size(h_parameters)
          h = np.zeros([h_length,], dtype=complex)
      
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(h),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:387:8: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          h_length = f_size(h_parameters)
          h = np.zeros([h_length,], dtype=complex)
      
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(h),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:387:8: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          h = np.zeros([h_length,], dtype=complex)
      
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(h),
              &h_parameters_struct,
              <const double complex *> np.PyArray_DATA(f),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:389:8: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          h = np.zeros([h_length,], dtype=complex)
      
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(h),
              &h_parameters_struct,
              <const double complex *> np.PyArray_DATA(f),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:389:8: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(h),
              &h_parameters_struct,
              <const double complex *> np.PyArray_DATA(f),
              &f_parameters_struct,
              <const double complex *> np.PyArray_DATA(g),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:391:8: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(h),
              &h_parameters_struct,
              <const double complex *> np.PyArray_DATA(f),
              &f_parameters_struct,
              <const double complex *> np.PyArray_DATA(g),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:391:8: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          hlmn_length = flmn_size(h_parameters)
          hlmn = np.zeros([hlmn_length,], dtype=complex)
      
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(hlmn),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:414:8: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          hlmn_length = flmn_size(h_parameters)
          hlmn = np.zeros([hlmn_length,], dtype=complex)
      
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(hlmn),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:414:8: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          hlmn = np.zeros([hlmn_length,], dtype=complex)
      
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(hlmn),
              &h_parameters_struct,
              <const double complex *> np.PyArray_DATA(flmn),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:416:8: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          hlmn = np.zeros([hlmn_length,], dtype=complex)
      
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(hlmn),
              &h_parameters_struct,
              <const double complex *> np.PyArray_DATA(flmn),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:416:8: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(hlmn),
              &h_parameters_struct,
              <const double complex *> np.PyArray_DATA(flmn),
              &f_parameters_struct,
              <const double complex *> np.PyArray_DATA(glmn),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:418:8: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          so3_conv_convolution(
              <double complex *> np.PyArray_DATA(hlmn),
              &h_parameters_struct,
              <const double complex *> np.PyArray_DATA(flmn),
              &f_parameters_struct,
              <const double complex *> np.PyArray_DATA(glmn),
              ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:418:8: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          hlmn_length = flmn_size(h_so3_parameters)
          hlmn = np.zeros([hlmn_length,], dtype=complex)
      
          so3_conv_s2toso3_harmonic_convolution(
          <double complex *> np.PyArray_DATA(hlmn),
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:434:4: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          hlmn_length = flmn_size(h_so3_parameters)
          hlmn = np.zeros([hlmn_length,], dtype=complex)
      
          so3_conv_s2toso3_harmonic_convolution(
          <double complex *> np.PyArray_DATA(hlmn),
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:434:4: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          hlmn = np.zeros([hlmn_length,], dtype=complex)
      
          so3_conv_s2toso3_harmonic_convolution(
          <double complex *> np.PyArray_DATA(hlmn),
          &h_parameters,
          <const double complex *> np.PyArray_DATA(flm),
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:436:4: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          hlmn = np.zeros([hlmn_length,], dtype=complex)
      
          so3_conv_s2toso3_harmonic_convolution(
          <double complex *> np.PyArray_DATA(hlmn),
          &h_parameters,
          <const double complex *> np.PyArray_DATA(flm),
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:436:4: Python objects cannot be cast to pointers of primitive types
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          so3_conv_s2toso3_harmonic_convolution(
          <double complex *> np.PyArray_DATA(hlmn),
          &h_parameters,
          <const double complex *> np.PyArray_DATA(flm),
          <const double complex *> np.PyArray_DATA(glm)
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:437:4: Casting temporary Python object to non-numeric non-Python type
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      
          so3_conv_s2toso3_harmonic_convolution(
          <double complex *> np.PyArray_DATA(hlmn),
          &h_parameters,
          <const double complex *> np.PyArray_DATA(flm),
          <const double complex *> np.PyArray_DATA(glm)
          ^
      ------------------------------------------------------------
      
      /tmp/pip-install-yyye2cij/so3_98ef28d04fc946bc9525212bfc49c4cd/src/so3/bindings.pyx:437:4: Python objects cannot be cast to pointers of primitive types
```
</details>

The changes in this PR update the code in the `src/so3/bindings.pyx` file to use the memoryview interface. With these changes I can build the package locally on Python 3.8 in a fresh Python virtual environment (and also build in Python 3.9+ which also didn't work locally for me previously).

As part of the changes I noticed some slightly confusing (to me) casting behaviour in the `so3.forward` function for dealing with the real signal case:

https://github.com/astro-informatics/so3/blob/02ab9affe6a0d578d95d01850bd079ef9cfe37e2/src/so3/bindings.pyx#L334-L346

Specifically in the real case, `flmn` is initialised as a real-valued (`double` data type) NumPy array but then cast to `double complex` pointer type when calling the `so3_core_forward_via_ssht_real` C function, while the signal argument `f` is always of complex type (`double complex` data type) but cast to a `const double` pointer when passed to the `so3_core_forward_via_ssht_real` C function. Is this the correct behaviour? My intuition would have been that the `flmn` coefficients should always be initialized as complex valued irrespective of the reality of the signal, but the signal argument `f` itself might have a real or complex value datatype depending on whether the reality flag has been set. The updated code in this PR follows along with this logic.

There wasn't previously a test to cover the real valued signal case. This PR tries to add one, but it is currently failing for me locally. This makes me think there may be some error in my logic above but I'm not sure exactly where so I though this was a good time to create a pull-request to ask!