### PR TITLE
Update Python build and publish workflow and bump version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,110 +1,103 @@
-name: Python Build
+name: Python tests, package build and publish on release
 
 env:
   # Set to avoid errors when building FFTW with CMake v4+
   # https://github.com/FFTW/fftw3/issues/381
   CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
-"on":
+on:
   push:
     branches: ["main"]
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
   pull_request:
+  release:
+    types:
+      - published
 
 jobs:
-  from-sdist:
-    name: python source distribution
-    runs-on: ubuntu-latest
+  tests:
+    name: Run tests on ${{matrix.os}} / Python ${{matrix.python-version}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
-
-      - name: Install build packages and pytest
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install "conan<2" scikit-build pytest cython numpy
-
-      - name: Create sdist
-        run: python setup.py sdist
-
-      - name: Install python so3
-        run: "pip install dist/so3-*.tar.gz"
-
+          python-version: ${{matrix.python-version}}
+      - name: Install so3
+        run: pip install ".[dev]"
       - name: run pytest
         run: pytest tests/
 
-      - uses: actions/upload-artifact@v4
-        if: ${{ startsWith(github.ref, 'refs/tags') }}
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          path: ./dist/*.tar.gz
-          name: source-distribution
+          python-version: 3.x
+      - name: Upgrade pip and install build
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build sdist
+        run: python -m build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pkg-sdist
+          path: dist/*.tar.gz
 
 
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  build-wheels:
+    name: Build wheels on ${{matrix.os}} / Python ${{matrix.python-version}}
+    runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-latest]
-        python-version: [3.8]
+        os: [macos-latest, ubuntu-latest]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v4
-        name: Install Python
+        name: Set up Python
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Setup environment
+      - name: Upgrade pip and install build
         run: |
-          python -m pip install --upgrade pip wheel
-          python -m pip install "conan<2" pytest
-          conan profile new default --detect
-
-      - name: Build wheels
-        run: pip wheel . --use-pep517 --no-deps -w dist
-
-      - name: install wheel
-        run: "pip install dist/*.whl"
-
-      - name: run pytests
-        run: pytest tests
-
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build sdist
+        run: python -m build --wheel
       - uses: actions/upload-artifact@v4
-        if: ${{ startsWith(github.ref, 'refs/tags') }}
         with:
-          path: ./dist/*.whl
-          name: wheel-${{matrix.os}}-${{matrix.python-version}}
+          name: pkg-wheel-${{matrix.os}}-${{matrix.python-version}}
+          path: dist/*.whl
 
-  publication:
-    name: publish to pypi
-    if: ${{ startsWith(github.ref, 'refs/tags') }}
+  publish:
+    name: Publish to PyPI
+    if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
-    needs: [build_wheels, from-sdist]
+    needs: [build-wheels, build-sdist]
     steps:
       - name: Download wheels and sdist
         uses: actions/download-artifact@v4
-
-      - name: Move wheels and source distribution to dist/
-        run: |
-            mkdir -p dist
-            mv source-distribution/*.tar.gz  wheel-*/*.whl dist
-
+        with:
+          pattern: pkg-*
+          path: dist
+          merge-multiple: true
       - name: Publish distribution 📦 to Test PyPI
-        if: ${{ github.ref != 'refs/tags/v1.3.6' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-
+          repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
-        if: ${{ github.ref == 'refs/tags/v1.3.6' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,9 +18,10 @@ jobs:
     name: Run tests on ${{matrix.os}} / Python ${{matrix.python-version}}
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -61,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +78,7 @@ jobs:
         run: python -m build --wheel
       - uses: actions/upload-artifact@v4
         with:
-          name: pkg-wheel-${{matrix.os}}-${{matrix.python-version}}
+          name: pkg-wheel-${{matrix.os}}-python-${{matrix.python-version}}
           path: dist/*.whl
 
   publish:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(
   so3
-  VERSION "1.3.6"
+  VERSION "1.3.7"
   DESCRIPTION "Fast and exact Wigner transforms"
   HOMEPAGE_URL "http://astro-informatics.github.io/so3/"
   LANGUAGES C)

--- a/makefile
+++ b/makefile
@@ -3,8 +3,7 @@
 
 CC	= gcc
 
-#OPT	= -Wall -O3 -fopenmp -DSO3_VERSION=\"0.1\" -DSO3_BUILD=\"`git rev-parse HEAD`\"
-OPT	= -Wall -g -fopenmp -DSO3_VERSION=\"1.3.6\" -DSO3_BUILD=\"`git rev-parse HEAD`\"
+OPT	= -Wall -g -fopenmp -DSO3_VERSION=\"1.3.7\" -DSO3_BUILD=\"`git rev-parse HEAD`\"
 
 
 # ======== LINKS ========

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.6
+current_version = 1.3.7
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ cmake_args = [
 
 setup(
     name="so3",
-    version="1.3.6",
+    version="1.3.7",
     author="Jason McEwen",
     install_requires=["numpy", "scipy"],
     extras_require={
@@ -35,4 +35,5 @@ setup(
     packages=["so3"],
     long_description=Path(__file__).with_name("README.md").read_text(),
     long_description_content_type="text/markdown",
+    python_requires=">=3.8"
 )


### PR DESCRIPTION
Updates Python build and publish workflow to 

- trigger on published release event rather than pattern matching tags for version identifiers,
- separate building sdist and running tests in to separate jobs,
- run tests on matrix of supported Python versions and operating systems,
- build wheels on matrix of supported Python versions and operating systems,
- update deprecated `repository_url` argument name to `pypa/gh-action-pypi-publish` Action to `repository-url`.

The version number is also manually bumped to 1.3.7. 